### PR TITLE
fix repeatability

### DIFF
--- a/src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.java
+++ b/src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.java
@@ -34,6 +34,7 @@ public class MinecartHandler {
     private BukkitTask task;
     private Boat boat;
     private ArmorStand modelStand;
+    private PacketAdapter boatInputListener;
 
     public MinecartHandler(MinecartMayhem plugin) {
         this.plugin = plugin;
@@ -113,7 +114,7 @@ public class MinecartHandler {
         // Add this map to track when the boat is climbing
         final Map<Player, Boolean> isClimbing = new HashMap<>();
 
-        protocolManager.addPacketListener(new PacketAdapter(plugin, ListenerPriority.NORMAL, PacketType.Play.Client.STEER_VEHICLE) {
+        this.boatInputListener = new PacketAdapter(plugin, ListenerPriority.NORMAL, PacketType.Play.Client.STEER_VEHICLE) {
             @Override
             public void onPacketReceiving(PacketEvent event) {
                 if (event.getPlayer() != player) return;
@@ -176,7 +177,10 @@ public class MinecartHandler {
                     isClimbing.put(player, false);
                 }
             }
-        });
+        };
+
+        // Register the packet listener;
+        protocolManager.addPacketListener(boatInputListener);
 
         task = new BukkitRunnable() {
             @Override
@@ -251,11 +255,13 @@ public class MinecartHandler {
     }
 
     public void stopBoatControl() {
-        if (task != null) {
-            task.cancel();
+        if (boatInputListener != null) {
+            protocolManager.removePacketListener(boatInputListener);
+            boatInputListener = null;
         }
-        this.boat.remove();
-        if (modelStand != null) modelStand.remove();
+        if (task != null) task.cancel();
+        boat.remove();
+        modelStand.remove();
     }
 
 }


### PR DESCRIPTION
This PR changes how MinecartHandlers are created and destroyed, enabling races to be repeated without any glaringly obvious issues.

This pull request refactors the `MinecartHandler` class to improve the management of the `PacketAdapter` used for boat input handling. The changes ensure proper cleanup of resources and improve code clarity by separating the creation and registration of the packet listener.

### Refactoring of boat input handling:

* Added a new `PacketAdapter` field `boatInputListener` to the `MinecartHandler` class to store the reference to the packet listener, allowing for better lifecycle management. (`[src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.javaR37](diffhunk://#diff-96bec858c5d63f83fbd6f7a0c7512ef672838811b54da96ad3e03b5f0183f341R37)`)
* Refactored the initialization of the `PacketAdapter` in the `startBoatControl` method to assign it to the `boatInputListener` field instead of creating an anonymous instance directly. (`[src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.javaL116-R117](diffhunk://#diff-96bec858c5d63f83fbd6f7a0c7512ef672838811b54da96ad3e03b5f0183f341L116-R117)`)
* Registered the `boatInputListener` with the `protocolManager` after its creation. This separates the listener's creation from its registration for better clarity. (`[src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.javaL179-R183](diffhunk://#diff-96bec858c5d63f83fbd6f7a0c7512ef672838811b54da96ad3e03b5f0183f341L179-R183)`)

### Resource cleanup improvements:

* Updated the `stopBoatControl` method to properly remove the `boatInputListener` from the `protocolManager` and set it to `null` to prevent memory leaks. The order of resource cleanup was also adjusted for consistency. (`[src/main/java/io/github/sbisel126/minecartMayhem/MinecartHandler.javaL254-R264](diffhunk://#diff-96bec858c5d63f83fbd6f7a0c7512ef672838811b54da96ad3e03b5f0183f341L254-R264)`)