### PR TITLE
Fix Racetimer

### DIFF
--- a/src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceHandler.java
+++ b/src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceHandler.java
@@ -57,10 +57,7 @@ public class RaceHandler {
     }
 
     public void StartRace() {
-        // toggle RaceInProgress to prevent users from joining the race
         RaceInProgress = true;
-
-        //display start of race graphic
         for (RacePlayer racePlayer : players) {
             if (racePlayer != null) {
                 RealPlayerCount++;
@@ -68,6 +65,17 @@ public class RaceHandler {
             }
         }
 
+        // Delay to match the countdown (3 seconds = 60 ticks)
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            for (RacePlayer racePlayer : players) {
+                if (racePlayer != null) {
+                    racePlayer.minecart.setFrozenBoat(false);
+                    racePlayer.setRacing(true);
+                    racePlayer.player.sendMessage("Race started!");
+                }
+            }
+            startRaceTimer();
+        }, 60L); // Delay matches "GO!" graphic timing
     }
 
     // starts the auto-incrementing timer
@@ -193,7 +201,6 @@ public class RaceHandler {
                 }
             }
             //start timer
-            startRaceTimer();
         }, 60L);
     }
 

--- a/src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceMoveListener.java
+++ b/src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceMoveListener.java
@@ -28,12 +28,6 @@ public class RaceMoveListener implements Listener {
         };
     }
 
-    private static String formatTime(int secs) {
-        int minutes = secs / 60;
-        int seconds = secs % 60;
-        return String.format("%d:%02d", minutes, seconds);
-    }
-
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();


### PR DESCRIPTION
This pull request includes updates to the race handling logic and code cleanup in the `minecartMayhem` project. The most important changes involve adding a delayed start to the race, removing an unused method, and ensuring proper placement of the race timer logic.

### Improvements to race handling:
* [`src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceHandler.java`](diffhunk://#diff-8efe19dc56675225168082f6c543c2a5c8386171a1b3166d73ec3b6be9cbfba1L60-R78): Added a 3-second (60-tick) delay before starting the race to synchronize with the countdown and "GO!" graphic. Players are notified when the race starts, and their minecarts are unfrozen. The race timer is now started after the delay.

### Code cleanup:
* [`src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceHandler.java`](diffhunk://#diff-8efe19dc56675225168082f6c543c2a5c8386171a1b3166d73ec3b6be9cbfba1L196): Removed a redundant call to `startRaceTimer` from the `displayRaceStartGraphic` method, as the timer is now started after the delay in `StartRace`.
* [`src/main/java/io/github/sbisel126/minecartMayhem/Race/RaceMoveListener.java`](diffhunk://#diff-c72842e3ac352e266cd4f4d380d70b17b70204824701d93aa54a5ce591c77b22L31-L36): Deleted the unused `formatTime` method to reduce clutter and improve code maintainability.